### PR TITLE
fix api doc mistake

### DIFF
--- a/dbbact_server/Seq_Flask.py
+++ b/dbbact_server/Seq_Flask.py
@@ -317,7 +317,7 @@ def get_sequence_annotations():
                 key: term (str)
                 value: dict of pairs:
                     'total_annotations' : number of annotations having this term in the database (int)
-                    'total_sequences' : number of sequences in annotations having this term in the database (int)
+                    'total_experiments' : number of unique experiments having at least one annotation with this term in the database (int)
         }
     Details :
         Validation:


### PR DESCRIPTION
fix the get_annotations() doc. It was saying the term_info returns 'total_sequences' but it actually contains total_experiments.
